### PR TITLE
Reformatted docker publish and changed docker-compose image

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: '43 4 * * *'
   push:
-    branches: [ "stable", "master" ] # TODO: Remove master once this is working
+    branches: [ "stable" ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:
@@ -18,7 +18,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,11 +25,10 @@ jobs:
       # This is used to complete the identity challenge
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
+      
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
@@ -70,7 +68,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: ./docker/django
-          dockerfile: dockerfile
+          file: ./docker/django/dockerfile
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,9 +3,7 @@ name: "csv"
 services:
   django:
     container_name: "csv_django"
-    build:
-      context: "./docker/django"
-      dockerfile: "dockerfile"
+    image: "ghcr.io/alexjthomson/csv-mapper"
     restart: "unless-stopped"
     privileged: false
     user: "1000:1000"


### PR DESCRIPTION
This PR updates the docker publish workflow to only create a new csv-mapper package on stable. This also changes the docker-compose file to point to the created image.